### PR TITLE
Add Browserbase agent link

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,6 +384,7 @@
         items: [
           { name: "HappyCapy.ai", url: "https://happycapy.ai", desc: "Autonomous Workflow Integrations" },
           { name: "Browser-Use Cloud", url: "https://browser-use.com", desc: "Vision-based Browser Agent Infrastructure" },
+          { name: "Browserbase", url: "https://gemini.browserbase.com/", desc: "Browser automation agent workspace" },
           { name: "Parallel AI", url: "https://parallel.ai", desc: "Parallel Task Agent Orchestration" },
           { name: "Agent.ai", url: "https://agent.ai", desc: "Developer Hub for Multi-agent Networks" },
           { name: "Manus AI", url: "https://manus.im", desc: "General-Purpose Digital Task Agent" },


### PR DESCRIPTION
### Motivation
- Provide quick access to Browserbase from the Agents section of the dashboard so users can launch the Browser automation agent workspace directly.

### Description
- Added a new entry to `database.agent.items` in `index.html`: `{ name: "Browserbase", url: "https://gemini.browserbase.com/", desc: "Browser automation agent workspace" }`.
- No other UI or behavior changes were made; the existing renderer will automatically include the new card and update counts.

### Testing
- Parsed `index.html` using Python's `HTMLParser`, which completed successfully.
- Started a local static server with `python -m http.server 8000` to serve the page and confirm the environment could render the file.
- Attempted automated visual verification with Playwright but it was unavailable in the environment, so the screenshot check was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e94eaecd4832f9e4dd98d24f13f8c)