### PR TITLE
Add Tech News dashboard section

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,6 +269,7 @@
     .sect-vibe .card:hover { --accent: #ec4899; }
     .sect-cli .card:hover { --accent: #06b6d4; }
     .sect-freebie .card:hover { --accent: #8b5cf6; }
+    .sect-technews .card:hover { --accent: #f97316; }
 
     .section-note {
       color: var(--text-muted);
@@ -323,6 +324,9 @@
       </button>
       <button class="nav-btn" onclick="filterSection('freebie', this)">
         <span>Free Tier Ops</span> <span class="count" id="cnt-freebie">0</span>
+      </button>
+      <button class="nav-btn" onclick="filterSection('technews', this)">
+        <span>Tech News</span> <span class="count" id="cnt-technews">0</span>
       </button>
     </nav>
     <button class="theme-toggle" onclick="toggleTheme()">🌓 <span>Theme</span></button>
@@ -429,6 +433,14 @@
           { name: "Neon", url: "https://neon.tech", desc: "Serverless Autoscaling Postgres Clusters" },
           { name: "PlanetScale", url: "https://planetscale.com", desc: "Serverless Database MySQL Alternative Platform" },
           { name: "MongoDB Atlas", url: "https://www.mongodb.com/atlas", desc: "Cloud Document-driven Store Cluster Engine" }
+        ]
+      },
+      technews: {
+        title: "Tech News",
+        items: [
+          { name: "Hacker News", url: "https://news.ycombinator.com", desc: "RSS: https://news.ycombinator.com/rss" },
+          { name: "Techmeme", url: "https://www.techmeme.com", desc: "RSS: https://www.techmeme.com/feed.xml" },
+          { name: "Ars Technica", url: "https://arstechnica.com", desc: "RSS: https://feeds.arstechnica.com/arstechnica/index" }
         ]
       }
     };


### PR DESCRIPTION
### Motivation
- Provide a dedicated "Tech News" cluster in the dashboard to surface major tech news sources and their RSS feeds for quick access and discovery.

### Description
- Added a new hover accent rule `.sect-technews .card:hover { --accent: #f97316; }` to style Tech News cards.
- Added a new sidebar navigation button for Tech News with a dynamic count badge (`id="cnt-technews"`) that integrates with the existing filtering UI.
- Added a `technews` entry to the `database` object with three items: Hacker News, Techmeme, and Ars Technica, and included the requested RSS URLs in each card `desc`.
- The existing rendering logic (`initDashboard`) and filtering/search functions automatically render the new section and update the count badge.

### Testing
- Ran the presence check with `python - <<'PY' ... PY` to assert the Tech News strings and RSS URLs are present, and it succeeded.
- Executed the inline script with `node - <<'NODE' ... NODE` to validate the embedded JavaScript parses and runs, and it succeeded.
- Ran `git diff --check` to verify there are no whitespace errors, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ff70f2a08832f9d00afb71d45dc63)