### PR TITLE
Add Slashdot and Lobste.rs to Tech News

### DIFF
--- a/index.html
+++ b/index.html
@@ -440,7 +440,9 @@
         items: [
           { name: "Hacker News", url: "https://news.ycombinator.com", desc: "RSS: https://news.ycombinator.com/rss" },
           { name: "Techmeme", url: "https://www.techmeme.com", desc: "RSS: https://www.techmeme.com/feed.xml" },
-          { name: "Ars Technica", url: "https://arstechnica.com", desc: "RSS: https://feeds.arstechnica.com/arstechnica/index" }
+          { name: "Ars Technica", url: "https://arstechnica.com", desc: "RSS: https://feeds.arstechnica.com/arstechnica/index" },
+          { name: "Slashdot", url: "https://slashdot.org", desc: "RSS: http://rss.slashdot.org/Slashdot/slashdotMain" },
+          { name: "Lobste.rs", url: "https://lobste.rs", desc: "RSS: https://lobste.rs/rss" }
         ]
       }
     };


### PR DESCRIPTION
### Motivation
- Add two additional tech RSS sources to the existing Tech News feed so the dashboard includes Slashdot and Lobste.rs.

### Description
- Updated `index.html` by adding `Slashdot` and `Lobste.rs` entries to `database.technews.items`, including their site URLs and RSS feed URLs in the `desc` fields.

### Testing
- Ran a short verification script `python - <<'PY' ... PY` that asserts the new site names and RSS URLs are present in `index.html`, and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ffa433c28832f9a4ec0d03d7d3910)