### PR TITLE
Add CORS-friendly feed fallbacks and switch Slashdot to HTTPS

### DIFF
--- a/feeds.html
+++ b/feeds.html
@@ -372,7 +372,7 @@
       { name: 'Hacker News', siteUrl: 'https://news.ycombinator.com', feedUrl: 'https://news.ycombinator.com/rss' },
       { name: 'Techmeme', siteUrl: 'https://www.techmeme.com', feedUrl: 'https://www.techmeme.com/feed.xml' },
       { name: 'Ars Technica', siteUrl: 'https://arstechnica.com', feedUrl: 'https://feeds.arstechnica.com/arstechnica/index' },
-      { name: 'Slashdot', siteUrl: 'https://slashdot.org', feedUrl: 'http://rss.slashdot.org/Slashdot/slashdotMain' },
+      { name: 'Slashdot', siteUrl: 'https://slashdot.org', feedUrl: 'https://rss.slashdot.org/Slashdot/slashdotMain' },
       { name: 'Lobste.rs', siteUrl: 'https://lobste.rs', feedUrl: 'https://lobste.rs/rss' },
       { name: 'The Register', siteUrl: 'https://www.theregister.com', feedUrl: 'https://www.theregister.com/headlines.atom' },
       { name: 'Computerworld', siteUrl: 'https://www.computerworld.com', feedUrl: 'https://www.computerworld.com/index.rss' },
@@ -447,25 +447,67 @@
     }
 
     async function fetchFeedXml(feedUrl, forceRefresh) {
-      const cacheBust = forceRefresh ? `?ts=${Date.now()}` : '';
-      const urls = [
-        `${feedUrl}${cacheBust}`,
-        `https://api.allorigins.win/raw?url=${encodeURIComponent(feedUrl)}${forceRefresh ? `&ts=${Date.now()}` : ''}`
-      ];
-
+      const proxiedRequests = buildFeedRequests(feedUrl, forceRefresh);
       let lastError;
-      for (const url of urls) {
+
+      for (const request of proxiedRequests) {
         try {
-          const response = await fetch(url, { cache: forceRefresh ? 'reload' : 'default' });
-          if (!response.ok) throw new Error(`HTTP ${response.status}`);
-          const text = await response.text();
-          if (!text.trim()) throw new Error('empty response');
-          return text;
+          const response = await fetch(request.url, { cache: forceRefresh ? 'reload' : 'default' });
+          if (!response.ok) throw new Error(`${request.label} returned HTTP ${response.status}`);
+          const body = await readFeedResponse(response, request.type);
+          if (!body.trim()) throw new Error(`${request.label} returned an empty response`);
+          return body;
         } catch (error) {
           lastError = error;
         }
       }
-      throw lastError || new Error('feed request failed');
+
+      throw new Error(`${lastError ? lastError.message : 'feed request failed'}. Browser RSS requests are often blocked by CORS; try a server-side proxy if every public proxy fails.`);
+    }
+
+    function buildFeedRequests(feedUrl, forceRefresh) {
+      const cacheKey = forceRefresh ? Date.now() : '';
+      const withCacheBust = addQueryParam(feedUrl, 'ts', cacheKey);
+      const encodedFeedUrl = encodeURIComponent(feedUrl);
+      const encodedCacheBustUrl = encodeURIComponent(withCacheBust);
+
+      return [
+        { label: 'Direct feed request', type: 'xml', url: withCacheBust },
+        { label: 'AllOrigins raw proxy', type: 'xml', url: `https://api.allorigins.win/raw?url=${encodedCacheBustUrl}` },
+        { label: 'AllOrigins JSON proxy', type: 'allOriginsJson', url: `https://api.allorigins.win/get?url=${encodedCacheBustUrl}` },
+        { label: 'RSS2JSON proxy', type: 'rss2json', url: `https://api.rss2json.com/v1/api.json?rss_url=${encodedFeedUrl}&count=${MAX_ITEMS_PER_FEED}${cacheKey ? `&ts=${cacheKey}` : ''}` }
+      ];
+    }
+
+    async function readFeedResponse(response, type) {
+      if (type === 'allOriginsJson') {
+        const data = await response.json();
+        return data.contents || '';
+      }
+      if (type === 'rss2json') {
+        const data = await response.json();
+        if (data.status && data.status !== 'ok') throw new Error(data.message || 'RSS2JSON could not read the feed');
+        return rss2JsonToXml(data);
+      }
+      return response.text();
+    }
+
+    function rss2JsonToXml(data) {
+      const items = (data.items || []).map(item => `
+        <item>
+          <title>${escapeHtml(item.title || '')}</title>
+          <link>${escapeHtml(item.link || '')}</link>
+          <pubDate>${escapeHtml(item.pubDate || '')}</pubDate>
+          <description>${escapeHtml(item.description || item.content || '')}</description>
+        </item>
+      `).join('');
+      return `<rss><channel>${items}</channel></rss>`;
+    }
+
+    function addQueryParam(url, key, value) {
+      if (!value) return url;
+      const separator = url.includes('?') ? '&' : '?';
+      return `${url}${separator}${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
     }
 
     function parseFeed(xmlText) {


### PR DESCRIPTION
### Motivation
- Feeds were failing to load in the browser due to CORS and mixed-content restrictions, causing many sources to show "Could not load this feed" errors. 
- The goal is to try multiple safe fallback proxies and surface clearer failure messages so the UI can still show stories when direct requests are blocked.

### Description
- Update `feeds.html` to use `https://rss.slashdot.org/...` instead of `http://` to avoid mixed-content blocking on secure pages. 
- Replace the single direct-fetch logic with `fetchFeedXml()` that iterates a prioritized list from `buildFeedRequests()` so each feed tries a direct request first and then several public proxies (`AllOrigins` raw/JSON and `rss2json`) as fallbacks. 
- Add `readFeedResponse()` to decode different proxy response shapes and `rss2JsonToXml()` to convert RSS2JSON results back into RSS-style XML so the existing parser continues to work. 
- Improve error text to explain common CORS causes and recommend a server-side proxy when public proxies fail, and add `addQueryParam()` helper for safe cache-busting.

### Testing
- Ran a JavaScript syntax check with `node --check /tmp/feeds-script.js`, which succeeded. 
- Issued a `curl -I -L --max-time 20 'https://news.ycombinator.com/rss'` check which returned a network `CONNECT tunnel failed, response 403` from the environment, indicating external network/proxy restrictions rather than a code error. 
- Attempted a programmatic `rss2json` probe with Python which also failed with a `403` tunnel error due to the environment network, so live feed verification was blocked by the runtime network rather than the updated client logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4001aed448832f940d85df27bfd43d)